### PR TITLE
fixed chrome fieldset bug; still need to make form properly tab-able

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,26 +46,36 @@
 
         <fieldset class="radio-landmarks">
 
-          <label for="parks" class="radio-label">
-            <input type="radio" id="parks" class="parks-radio" name="landmark">
-            <span class="button">Parks</span>
-          </label>
+          <div class="radio-labels-container">
 
-          <label for="schools" class="radio-label">
-            <input type="radio" id="schools" class="schools-radio" name="landmark">
-            <span class="button">Schools</span>
-          </label>
+            <label for="parks" class="radio-label">
+              <input type="radio" id="parks" class="parks-radio" name="landmark">
+              <span class="button">Parks</span>
+            </label>
+
+            <label for="schools" class="radio-label">
+              <input type="radio" id="schools" class="schools-radio" name="landmark">
+              <span class="button">Schools</span>
+            </label>
+            
+          </div>
 
         </fieldset>
 
         <fieldset class="dropdown-location">
 
-          <label for="location" class="select-location-label">
-            <span class="sr-only">Locations</span>
-            <select name="location" id="location" class="select-location">
-              <option value="">Choose Landmark First</option>
-            </select>
-          </label>
+          <legend class="sr-only">Select A Location</legend>
+
+          <div class="select-location-container">
+
+            <label for="location" class="select-location-label">
+              <span class="sr-only">Locations</span>
+              <select name="location" id="location" class="select-location">
+                <option value="">Choose Landmark First</option>
+              </select>
+            </label>
+
+          </div>
 
         </fieldset>
 

--- a/styles/sass/_global.scss
+++ b/styles/sass/_global.scss
@@ -47,6 +47,6 @@ a {
 .button {
     border: none;
     border-radius: 4px;
-    background: $bike-orange;
+    background: $highlight;
     text-transform: uppercase;
 }

--- a/styles/sass/_main.scss
+++ b/styles/sass/_main.scss
@@ -19,9 +19,11 @@
     }
 
     .radio-landmarks {
-        display: flex;
-        margin: 30px 0;     
+        margin: 30px 0;   
         
+        .radio-labels-container {
+            display: flex;
+        }
 
         .radio-label {
             flex: 1 1 auto;
@@ -59,9 +61,12 @@
     }
 
     .dropdown-location {
-        display: flex;
-        justify-content: center;
         margin: 30px 0;
+
+        .select-location-container {
+            display: flex;
+            justify-content: center;
+        }
 
         .select-location {
             width: 250px;

--- a/styles/style.css
+++ b/styles/style.css
@@ -273,8 +273,7 @@ a {
 
 .wrapper {
   max-width: 1280px;
-  margin-right: auto;
-  margin-left: auto;
+  margin: 0 auto;
   padding-right: 10px;
   padding-left: 10px;
 }
@@ -398,10 +397,13 @@ header {
 }
 
 .form-location .radio-landmarks {
+  margin: 30px 0;
+}
+
+.form-location .radio-landmarks .radio-labels-container {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
-  margin: 30px 0;
 }
 
 .form-location .radio-landmarks .radio-label {
@@ -442,13 +444,16 @@ header {
 }
 
 .form-location .dropdown-location {
+  margin: 30px 0;
+}
+
+.form-location .dropdown-location .select-location-container {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  margin: 30px 0;
 }
 
 .form-location .dropdown-location .select-location {
@@ -594,7 +599,8 @@ footer a {
   text-decoration: underline;
 }
 
-footer a:hover {
+footer a:hover,
+footer a:focus {
   color: #FFFFFA;
 }
 


### PR DESCRIPTION
- Added a div to act as flex parent within the form (.form-location).  This was done within the fieldsets .radio-landmarks and .dropdown-location.  Within Chrome, fieldsets cannot act as a flex parent, which, I believe, is just a weird bug unique to Chrome.  This was fixed by using the div as a flex-parent instead while maintaining the semantics by keeping the fieldset elements.  

- The tab-ability is still weird within Chrome, and I think it might have to do with the inherent semantics of fieldsets/legends.  This is just a hunch, but I'll start another branch to debug that soon.